### PR TITLE
Fix crash caused by consuming bad API data

### DIFF
--- a/app/src/main/java/com/codefororlando/streettrees/api/deserializer/ResponseSanitizer.java
+++ b/app/src/main/java/com/codefororlando/streettrees/api/deserializer/ResponseSanitizer.java
@@ -1,0 +1,59 @@
+// Copyright © 2017 Code for Orlando.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package com.codefororlando.streettrees.api.deserializer;
+
+import com.codefororlando.streettrees.api.models.Tree;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+// NOTE(jpr): adapted from
+// https://static.javadoc.io/com.google.code.gson/gson/2.8.0/com/google/gson/Gson.html#getDelegateAdapter-com.google.gson.TypeAdapterFactory-com.google.gson.reflect.TypeToken-
+public class ResponseSanitizer implements TypeAdapterFactory {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+        return new TypeAdapter<T>() {
+            public void write(JsonWriter out, T value) throws IOException {
+                delegate.write(out, value);
+            }
+            public T read(JsonReader in) throws IOException {
+                T parsedObject = delegate.read(in);
+
+                // NOTE(jpr): Tree names come in with errant whitespace, and its easiest to fix it here
+                // rather than fighting retrofit during deserialization
+                if ( parsedObject instanceof Tree ) {
+                    Tree tree = (Tree) parsedObject;
+                    tree.setTreeName(tree.getTreeName().trim());
+                }
+
+                return parsedObject;
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/codefororlando/streettrees/api/providers/TreeProvider.java
+++ b/app/src/main/java/com/codefororlando/streettrees/api/providers/TreeProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.codefororlando.streettrees.api.TreeAPIService;
 import com.codefororlando.streettrees.api.deserializer.LatLngDeserializer;
+import com.codefororlando.streettrees.api.deserializer.ResponseSanitizer;
 import com.codefororlando.streettrees.api.models.Tree;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.gson.Gson;
@@ -46,6 +47,7 @@ public class TreeProvider implements TreeProviderInterface {
         Gson gson = new GsonBuilder()
                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ss")
                 .registerTypeAdapter(LatLng.class, new LatLngDeserializer())
+                .registerTypeAdapterFactory(new ResponseSanitizer())
                 .create();
 
         Retrofit retrofit = new Retrofit.Builder()


### PR DESCRIPTION
Tree names have trailing spaces a lot, but we were assuming they didn't. This was causing a crash when trying to click into a tree detail view.