### PR TITLE
Prevent Crashing When Tree Name Cannot Be Found in the Cache

### DIFF
--- a/app/src/main/java/com/codefororlando/streettrees/activity/DetailActivity.java
+++ b/app/src/main/java/com/codefororlando/streettrees/activity/DetailActivity.java
@@ -41,9 +41,15 @@ public class DetailActivity extends AppCompatActivity implements DetailFragment.
         treeType = loadingIntent.getStringExtra(MainActivity.EXTRA_TREETYPE);
     }
 
-    @Override
-    public TreeDescription getTreeData() {
-        return treeDescriptionProvider.getTreeDescription(treeType);
-
-    }
+	@Override
+	public TreeDescription getTreeData() {
+		try {
+			return treeDescriptionProvider.getTreeDescription(treeType);
+		} catch(IllegalArgumentException iae){
+			Toast badTreeMsg = Toast.makeText(this.getApplicationContext(),
+					iae.getMessage(), Toast.LENGTH_SHORT);
+			badTreeMsg.show();
+			return null;
+	}
+}
 }

--- a/app/src/main/java/com/codefororlando/streettrees/api/providers/TreeDescriptionProvider.java
+++ b/app/src/main/java/com/codefororlando/streettrees/api/providers/TreeDescriptionProvider.java
@@ -28,6 +28,7 @@ public class TreeDescriptionProvider {
     }
 
     public TreeDescription getTreeDescription(String name) {
+        name = name.trim();
         if (!treeCache.containsKey(name)) {
             throw new IllegalArgumentException("Tree name not in the cache");
         }

--- a/app/src/main/java/com/codefororlando/streettrees/fragments/DetailFragment.java
+++ b/app/src/main/java/com/codefororlando/streettrees/fragments/DetailFragment.java
@@ -45,7 +45,18 @@ public class DetailFragment extends Fragment {
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        TreeDescription treeDescription = activityListener.getTreeData();
+        TreeDescription treeDescription = null;
+		try {
+			treeDescription = activityListener.getTreeData();
+		} catch(NullPointerException np){
+			this.getActivity().finish();
+			return;
+		}
+
+		if(treeDescription == null){
+			this.getActivity().finish();
+			return;
+		}
 
         ((TextView) layoutView.findViewById(R.id.treeHeight)).setText(treeDescription.getMinHeight());
         ((TextView) layoutView.findViewById(R.id.treeLeaf)).setText(treeDescription.getLeaf());


### PR DESCRIPTION
This should keep the app from crashing when the tree name cannot be found in the cache.