### PR TITLE
Fix kotlin/kodein conversion bugs

### DIFF
--- a/app/src/main/java/com/codefororlando/streettrees/activity/MainActivity.kt
+++ b/app/src/main/java/com/codefororlando/streettrees/activity/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : KodeinAppCompatActivity(),
 
     private val treeProvider: ITreeProvider by instance()
     private val presenter: MapPresenter = MapPresenter()
-    private val cachedTrees: MutableList<Tree> = mutableListOf()
+    private var cachedTrees: List<Tree> = listOf()
 
     private lateinit var locationManager: LocationManager
     private lateinit var locationProvider: String
@@ -93,7 +93,7 @@ class MainActivity : KodeinAppCompatActivity(),
     override fun onStop() {
         super.onStop()
         presenter.detach()
-        cachedTrees.clear()
+        cachedTrees = emptyList()
     }
 
     @TargetApi(Build.VERSION_CODES.M)
@@ -135,9 +135,7 @@ class MainActivity : KodeinAppCompatActivity(),
     }
 
     override fun updateMapWithTrees(trees: List<Tree>?) {
-        if (trees == null) {
-            return
-        }
+        trees ?: return
 
         val vr = map.projection.visibleRegion
         val visibleTrees = presenter.getVisibleTrees(vr, trees, DEFAULT_MARKER_LIMIT)
@@ -145,8 +143,7 @@ class MainActivity : KodeinAppCompatActivity(),
             map.addMarker(MarkerOptions().position(tree.location).title(tree.treeName))
         }
 
-        cachedTrees.clear()
-        cachedTrees.addAll(trees)
+        cachedTrees = trees
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/com/codefororlando/streettrees/fragments/DetailFragment.kt
+++ b/app/src/main/java/com/codefororlando/streettrees/fragments/DetailFragment.kt
@@ -35,8 +35,8 @@ import com.codefororlando.streettrees.api.models.TreeDescription
 
 class DetailFragment : Fragment() {
 
-    private var activityListener: DetailListener? = null
-    private var layoutView: View? = null
+    private lateinit var activityListener: DetailListener
+    private lateinit var layoutView: View
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -54,17 +54,17 @@ class DetailFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        val treeDescription = activityListener!!.treeData
+        val treeDescription = activityListener.treeData
 
-        (layoutView!!.findViewById(R.id.treeHeight) as TextView).text = treeDescription.minHeight
-        (layoutView!!.findViewById(R.id.treeLeaf) as TextView).text = treeDescription.leaf
-        (layoutView!!.findViewById(R.id.treeShape) as TextView).text = treeDescription.shape
-        (layoutView!!.findViewById(R.id.treeWidth) as TextView).text = treeDescription.minWidth
-        (layoutView!!.findViewById(R.id.treeSunlight) as TextView).text = treeDescription.sunlight
-        (layoutView!!.findViewById(R.id.treSoil) as TextView).text = treeDescription.soil
-        (layoutView!!.findViewById(R.id.treeMoisture) as TextView).text = treeDescription.moisture
-        (layoutView!!.findViewById(R.id.treeDescription) as TextView).text = treeDescription.description
-        (layoutView!!.findViewById(R.id.treeType) as TextView).text = treeDescription.name
+        (layoutView.findViewById(R.id.treeHeight) as TextView).text = treeDescription.minHeight
+        (layoutView.findViewById(R.id.treeLeaf) as TextView).text = treeDescription.leaf
+        (layoutView.findViewById(R.id.treeShape) as TextView).text = treeDescription.shape
+        (layoutView.findViewById(R.id.treeWidth) as TextView).text = treeDescription.minWidth
+        (layoutView.findViewById(R.id.treeSunlight) as TextView).text = treeDescription.sunlight
+        (layoutView.findViewById(R.id.treSoil) as TextView).text = treeDescription.soil
+        (layoutView.findViewById(R.id.treeMoisture) as TextView).text = treeDescription.moisture
+        (layoutView.findViewById(R.id.treeDescription) as TextView).text = treeDescription.description
+        (layoutView.findViewById(R.id.treeType) as TextView).text = treeDescription.name
     }
 
     interface DetailListener {

--- a/app/src/main/java/com/codefororlando/streettrees/requesttree/RequestTreeActivity.java
+++ b/app/src/main/java/com/codefororlando/streettrees/requesttree/RequestTreeActivity.java
@@ -23,7 +23,6 @@
 package com.codefororlando.streettrees.requesttree;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import com.codefororlando.streettrees.R;
@@ -34,11 +33,12 @@ import com.codefororlando.streettrees.requesttree.deliveryaddress.AddressFormFra
 import com.codefororlando.streettrees.requesttree.selecttree.SelectTreeFragment;
 import com.codefororlando.streettrees.view.FragmentListPager;
 import com.codefororlando.streettrees.view.PageFragment;
+import com.github.salomonbrys.kodein.android.KodeinAppCompatActivity;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class RequestTreeActivity extends AppCompatActivity implements PageFragment.PageFragmentListener,
+public class RequestTreeActivity extends KodeinAppCompatActivity implements PageFragment.PageFragmentListener,
         AddressFormFragment.AddressFormListener,
         ContactInfoFragment.ContactInfoListener,
         RequestReviewFragment.ReviewFragmentDelegate {

--- a/app/src/main/java/com/codefororlando/streettrees/requesttree/selecttree/SelectTreeFragment.kt
+++ b/app/src/main/java/com/codefororlando/streettrees/requesttree/selecttree/SelectTreeFragment.kt
@@ -35,12 +35,13 @@ import com.codefororlando.streettrees.requesttree.BlurredBackgroundFragment
 import com.codefororlando.streettrees.util.TreeDrawableResourceProvider
 import com.codefororlando.streettrees.view.ImageViewPagerAdapter
 import com.github.salomonbrys.kodein.KodeinInjector
-import com.github.salomonbrys.kodein.android.FragmentInjector
+import com.github.salomonbrys.kodein.android.SupportFragmentInjector
+import com.github.salomonbrys.kodein.instance
 
 class SelectTreeFragment : BlurredBackgroundFragment(),
         SelectTreePresenter.SelectTreeView,
         ViewPager.OnPageChangeListener,
-        FragmentInjector {
+        SupportFragmentInjector {
 
     override val injector: KodeinInjector = KodeinInjector()
 
@@ -58,13 +59,20 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
     private var presenter: SelectTreePresenter? = null
     private var pageIndex: Int = 0
 
-    private var treeDescriptionProvider: TreeDescriptionProvider? = null
-    private var treeDrawableResourceProvider: TreeDrawableResourceProvider? = null
+    private val treeDescriptionProvider: TreeDescriptionProvider by instance()
+    private val treeDrawableResourceProvider: TreeDrawableResourceProvider = TreeDrawableResourceProvider()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initializeInjector()
+
         adapter = ImageViewPagerAdapter(activity)
         presenter = SelectTreePresenter(treeDescriptionProvider, treeDrawableResourceProvider)
+    }
+
+    override fun onDestroy() {
+        destroyInjector()
+        super.onDestroy()
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/codefororlando/streettrees/requesttree/selecttree/SelectTreeFragment.kt
+++ b/app/src/main/java/com/codefororlando/streettrees/requesttree/selecttree/SelectTreeFragment.kt
@@ -45,18 +45,18 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
 
     override val injector: KodeinInjector = KodeinInjector()
 
-    private var nextButton: Button? = null
-    private var pager: ViewPager? = null
-    private var adapter: ImageViewPagerAdapter? = null
+    private lateinit var nextButton: Button
+    private lateinit var pager: ViewPager
+    private lateinit var adapter: ImageViewPagerAdapter
 
-    private var treeNameLabel: TextView? = null
-    private var descriptionLabel: TextView? = null
-    private var widthLabel: TextView? = null
-    private var heightLabel: TextView? = null
-    private var leafLabel: TextView? = null
-    private var shapeLabel: TextView? = null
+    private lateinit var treeNameLabel: TextView
+    private lateinit var descriptionLabel: TextView
+    private lateinit var widthLabel: TextView
+    private lateinit var heightLabel: TextView
+    private lateinit var leafLabel: TextView
+    private lateinit var shapeLabel: TextView
 
-    private var presenter: SelectTreePresenter? = null
+    private lateinit var presenter: SelectTreePresenter
     private var pageIndex: Int = 0
 
     private val treeDescriptionProvider: TreeDescriptionProvider by instance()
@@ -83,21 +83,21 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
         return view
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState!!.putInt(PAGER_INDEX_KEY, pager!!.currentItem)
+        outState.putInt(PAGER_INDEX_KEY, pager.currentItem)
     }
 
     override fun onStart() {
         super.onStart()
         activity.title = getString(R.string.select_tree_fragment_title)
-        presenter!!.attach(this)
-        presenter!!.loadTreeDescriptions()
+        presenter.attach(this)
+        presenter.loadTreeDescriptions()
     }
 
     override fun onStop() {
         super.onStop()
-        presenter!!.detach()
+        presenter.detach()
     }
 
     override fun present(treeViewModels: List<TreeViewModel>) {
@@ -106,7 +106,7 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
         for (i in 0..count - 1) {
             imageResIds[i] = treeViewModels[i].drawableResId
         }
-        adapter!!.setImages(imageResIds)
+        adapter.setImages(imageResIds)
         onPageSelected(0)
     }
 
@@ -119,12 +119,12 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
         shapeLabel = view.findViewById(R.id.shape) as TextView
 
         nextButton = view.findViewById(R.id.next_button) as Button
-        nextButton!!.setOnClickListener { nextFragment() }
+        nextButton.setOnClickListener { nextFragment() }
 
         pager = view.findViewById(R.id.view_pager) as ViewPager
-        pager!!.adapter = adapter
-        pager!!.addOnPageChangeListener(this)
-        pager!!.offscreenPageLimit = 1
+        pager.adapter = adapter
+        pager.addOnPageChangeListener(this)
+        pager.offscreenPageLimit = 1
     }
 
     internal fun nextFragment() {
@@ -136,18 +136,18 @@ class SelectTreeFragment : BlurredBackgroundFragment(),
         val width = String.format("%s - %s", tree.minWidth, tree.maxWidth)
         val height = String.format("%s - %s", tree.minHeight, tree.maxHeight)
 
-        treeNameLabel!!.text = tree.name
-        descriptionLabel!!.text = tree.description
-        widthLabel!!.text = width
-        heightLabel!!.text = height
-        leafLabel!!.text = tree.leaf
-        shapeLabel!!.text = tree.shape
+        treeNameLabel.text = tree.name
+        descriptionLabel.text = tree.description
+        widthLabel.text = width
+        heightLabel.text = height
+        leafLabel.text = tree.leaf
+        shapeLabel.text = tree.shape
     }
 
     override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {}
 
     override fun onPageSelected(position: Int) {
-        val treeViewModel = presenter!!.getTreeViewModel(position)
+        val treeViewModel = presenter.getTreeViewModel(position)
         if (treeViewModel != null) {
             bindTreeViewModel(treeViewModel)
         }


### PR DESCRIPTION
Looks like there were a couple regressions

- Main map was clearing out the tree cache state when the user moved due to the variable being passed by reference
- Select tree activity wasn't fully converted to use kodein
- Some lateinit changes to avoid needing to rely on `!!`